### PR TITLE
force-signer option to force specific keyid

### DIFF
--- a/libpius/signer.py
+++ b/libpius/signer.py
@@ -33,10 +33,17 @@ class PiusSigner(object):
   GPG_SIG_BEG = '[GNUPG:] BEGIN_SIGNING'
   GPG_SIG_CREATED = '[GNUPG:] SIG_CREATED'
 
-  def __init__(self, signer, mode, keyring, gpg_path, tmpdir, outdir,
-               encrypt_outfiles, mail, mailer, verbose, sort_keyring,
+  def __init__(self, signer, force_signer, mode, keyring, gpg_path, tmpdir,
+               outdir, encrypt_outfiles, mail, mailer, verbose, sort_keyring,
                policy_url, mail_host):
     self.signer = signer
+    if not force_signer:
+      # If force_signer is not specified let gpg guess by using the main keyid
+      self.force_signer = self.signer
+    else:
+      # If force_signer is specified make sure that gpg uses this keyid by
+      # putting '!' at the end
+      self.force_signer = force_signer + '!'
     self.mode = mode
     self.keyring = keyring
     self.sort_keyring = sort_keyring
@@ -559,7 +566,7 @@ class PiusSigner(object):
     # Note that if passphrase-fd is different from command-fd, nothing works.
     cmd = [self.gpg] + self.gpg_base_opts + self.gpg_quiet_opts + \
       self.gpg_fd_opts + keyring + [
-          '-u', self.signer,
+          '-u', self.force_signer,
       ] + agent + [
           '--default-cert-level', level,
           '--no-ask-cert-level',
@@ -823,7 +830,7 @@ class PiusSigner(object):
           '--keyring', self.tmp_keyring,
           '--no-options',
           '--always-trust',
-          '-u', self.signer,
+          '-u', self.force_signer,
           '-aes',
           '-r', keyid,
           '-r', self.signer,

--- a/libpius/util.py
+++ b/libpius/util.py
@@ -12,6 +12,7 @@ DEBUG_ON = False
 VALID_OPTIONS = [
     '--mail',
     '--signer',
+    '--force-signer',
     '--use-agent',
     '--import',
     '--mail-host',

--- a/pius
+++ b/pius
@@ -187,6 +187,10 @@ def main():
   parser.add_option('-s', '--signer', dest='signer', nargs=1,
                     type='keyid',
                     help='The keyid to sign with (required).')
+  parser.add_option('-f', '--force-signer', dest='force_signer',
+                    type='keyid',
+                    help='Force GnuPG to use this exact keyid to sign (do not'
+                         ' guess subkey)')
   parser.add_option('-S', '--no-mail-tls', action='store_false',
                     dest='mail_tls',
                     help='Do not use STARTTLS when talking to the SMTP server.')
@@ -252,6 +256,7 @@ def main():
 
   signer = psigner.PiusSigner(
       options.signer,
+      options.force_signer,
       options.mode,
       options.keyring,
       options.gpg_path,


### PR DESCRIPTION
By default, GnuPG will guess the "best" key or subkey to sign a key
with. This can fail if the "best" subkey is not available (for example
when the subkey is on a smartcard and the card is not inserted). The new
--force-signer option forces GnuPG to use the specified signer instead
of guessing the best key.