### PR TITLE
Skip progress messages during encrypt_signed_uid.

### DIFF
--- a/libpius/signer.py
+++ b/libpius/signer.py
@@ -432,6 +432,9 @@ class PiusSigner(object):
         # we get a ENC_INV.
         debug('Got GPG_KEY_EXP')
         continue
+      elif PiusSigner.GPG_PROGRESS in line:
+        debug('Got skippable stuff')
+        continue
       else:
         raise EncryptionUnknownError(line)
 


### PR DESCRIPTION
This is done in `encrypt_and_sign_file`, but it can also be triggered in `encrypt_signed_uid`.