### PR TITLE
Fix buggy statement re template text

### DIFF
--- a/pius
+++ b/pius
@@ -31,11 +31,12 @@ import sys
 
 def print_default_email(no_mime):
   '''Print the default email that is sent out.'''
-  interpolation_dict = {'keyid': '[KEYID]', 'signer': '[SIGNER]',
-                        'email': '[EMAIL]'}
+  interpolation_dict = {}
+  for p in ('keyid', 'signer', 'email'):
+      interpolation_dict[p] = '%(' + p + ')s'
   print(
     '  The default email text is below. To specify your own, simply use\n'
-    '  %(keyid) %(signer) and %(email) in the body and they will be\n'
+    '  %(keyid)s %(signer)s and %(email)s in the body and they will be\n'
     '  replaced with the relevant strings.\n'
   )
   print '  DEFAULT EMAIL TEXT:\n'


### PR DESCRIPTION
The statement about the templatization of the email said `%(foo)` where
it should have said `%(foo)s` per normal Python percent interpolation.

Fix the statement to be correct, and for the normalization, for each
`foo` expand to `%(foo)s` instead of `[FOO]` so that the output can be
copy/pasted into a file and used as an intact starting point.