### PR TITLE
Fix Remove signing key from  trustdb (#47)

### DIFF
--- a/libpius/signer.py
+++ b/libpius/signer.py
@@ -497,7 +497,7 @@ class PiusSigner(object):
     cmd = [self.gpg] + self.gpg_base_opts + self.gpg_quiet_opts + [
         '--no-default-keyring',
         '--keyring', self.tmp_keyring,
-        '--import-options', 'import-minimal',
+        '--import-options', 'import-minimal,keep-ownertrust',
         '--import', path,
     ]
     self._run_and_check_status(cmd)


### PR DESCRIPTION
When pius imports the keys into the temporary pius_pubring.gpg using gpg2 (gpg (GnuPG) 2.1.11) the signing key may end up being removed from the default ownertrust database ~/.gnupg/trustdb.gpg.
This fix prevents that by adding the keep-ownertrust import-option to the signer.import_clean_key function.
No other key and keyring imports are touched by this fix.