### PR TITLE
Fix Remove signing key from trustdb (#47)

### DIFF
--- a/libpius/signer.py
+++ b/libpius/signer.py
@@ -481,28 +481,27 @@ class PiusSigner(object):
   def export_clean_key(self, key):
     '''Export clean key from the users' KeyID.'''
     # Export our public key and the given public key
-    for k in [self.signer, key]:
-       debug('exporting %s' % k)
-       path = self._tmpfile_path('%s.asc' % k)
-       self._export_key(self.keyring, [k], path)
+    for x in [self.signer, key]:
+       debug('exporting %s' % x)
+       path = self._tmpfile_path('%s.asc' % x)
+       self._export_key(self.keyring, [x], path)
 
   def clean_clean_key(self, key):
     '''Delete the "clean" unsigned key which we exported temporarily.'''
     # Remove the temporary exports of the public keys
-    for k in [self.signer, key]:
-        path = self._tmpfile_path('%s.asc' % k)
-        clean_files([path])
+    paths = [self._tmpfile_path('%s.asc' % x) for x in [self.signer, key]]
+    clean_files(paths)
 
   def import_clean_key(self, key):
     '''Import the clean key we exported in export_clean_key() to our temp
     keyring.'''
     # Import the export of our public key and the given public key
-    for k in [self.signer, key]:
-        debug('importing %s' % k)
+    for x in [self.signer, key]:
+        debug('importing %s' % x)
         import_opts = ['import-minimal']
-        if k == self.signer:
+        if x == self.signer:
             import_opts.append('keep-ownertrust')
-        path = self._tmpfile_path('%s.asc' %  k)
+        path = self._tmpfile_path('%s.asc' %  x)
         cmd = [self.gpg] + self.gpg_base_opts + self.gpg_quiet_opts + [
             '--no-default-keyring',
             '--keyring', self.tmp_keyring,

--- a/libpius/signer.py
+++ b/libpius/signer.py
@@ -480,28 +480,36 @@ class PiusSigner(object):
 
   def export_clean_key(self, key):
     '''Export clean key from the users' KeyID.'''
-    debug('exporting %s' % key)
-    # We have to export our own public key as well
-    keys_to_export = [key, self.signer]
-    path = self._tmpfile_path('%s.asc' % key)
-    self._export_key(self.keyring, keys_to_export, path)
+    # Export our public key and the given public key
+    for k in [self.signer, key]:
+       debug('exporting %s' % k)
+       path = self._tmpfile_path('%s.asc' % k)
+       self._export_key(self.keyring, [k], path)
 
   def clean_clean_key(self, key):
     '''Delete the "clean" unsigned key which we exported temporarily.'''
-    path = self._tmpfile_path('%s.asc' % key)
-    clean_files([path])
+    # Remove the temporary exports of the public keys
+    for k in [self.signer, key]:
+        path = self._tmpfile_path('%s.asc' % k)
+        clean_files([path])
 
   def import_clean_key(self, key):
-    '''Import the clean key we expoerted in export_clean_key() to our temp
+    '''Import the clean key we exported in export_clean_key() to our temp
     keyring.'''
-    path = self._tmpfile_path('%s.asc' %  key)
-    cmd = [self.gpg] + self.gpg_base_opts + self.gpg_quiet_opts + [
-        '--no-default-keyring',
-        '--keyring', self.tmp_keyring,
-        '--import-options', 'import-minimal',
-        '--import', path,
-    ]
-    self._run_and_check_status(cmd)
+    # Import the export of our public key and the given public key
+    for k in [self.signer, key]:
+        debug('importing %s' % k)
+        import_opts = ['import-minimal']
+        if k == self.signer:
+            import_opts.append('keep-ownertrust')
+        path = self._tmpfile_path('%s.asc' %  k)
+        cmd = [self.gpg] + self.gpg_base_opts + self.gpg_quiet_opts + [
+            '--no-default-keyring',
+            '--keyring', self.tmp_keyring,
+            '--import-options', ','.join(import_opts),
+            '--import', path,
+        ]
+        self._run_and_check_status(cmd)
 
   def policy_opts(self):
     if self.policy_url:


### PR DESCRIPTION
When pius imports the keys into the temporary pius_pubring.gpg using
gpg2 the signing key may end up being removed from the default
ownertrust database ~/.gnupg/trustdb.gpg (Issue #47).

This fix prevents pius from removing the signing key from the default
ownertrust database by:
- exporting the signing key and the key to be signed into 2 separate
  export files, one for the signer key and one for the key to be signed
- importing the signing key and the key to be signed from these 2
  export files using:
  - '--import-options import-minimal' to import the key to be signed
    into the temporary keyring
  - '--import-options import-minimal,keep-ownertrust' to import the
    signer key into the temporary keyring