### PR TITLE
Fix docs/errors

### DIFF
--- a/libpius/signer.py
+++ b/libpius/signer.py
@@ -469,7 +469,9 @@ class PiusSigner(object):
     if retval != 0:
       # We don't catch this, but that's fine, if this errors, a stack
       # trace is what we want
-      raise GpgUnknownError("'%s' exited with %d" % (' '.join(cmd), retval))
+      raise GpgUnknownError("'%s' exited with %d" % (
+        ' '.join(cmd) if isinstance(cmd, list) else cmd, retval
+      ))
 
   def _export_key(self, keyring, keys, path):
     '''Internal function used by other export_* functions.'''

--- a/pius
+++ b/pius
@@ -177,8 +177,9 @@ def main():
   parser.add_option('-r', '--keyring', dest='keyring', metavar='KEYRING',
                     nargs=1, type='not_another_opt',
                     help='The keyring to use. Be sure to specify full or'
-                         ' relative path. Just a filename will cause GPG to'
-                         ' assume relative to ~/.gnupg. [default: %default]')
+                         ' relative path. Use a path: Just a filename may cause'
+                         ' GPG to assume relative to ~/.gnupg and cause'
+                         ' unexpected results. [default: %default]')
   parser.add_option('-s', '--signer', dest='signer', nargs=1,
                     type='keyid',
                     help='The keyid to sign with (required).')


### PR DESCRIPTION
Update the help message to better describe the problem with bare
filenames. Closes #41

Also fix error messages when shell was used.