### PR TITLE
Add option to use email display name (full name)

### DIFF
--- a/libpius/mailer.py
+++ b/libpius/mailer.py
@@ -252,7 +252,10 @@ class PiusMailer(object):
     # We don't duplicate the header logic in the sub functions, we
     # do that here
     debug("send_mail called with to (%s), subject (%s)" % (to, msg['subject']))
-    msg['From'] = self.mail
+    if self.display_name:
+      msg['From'] = self.display_name + ' <' + self.mail + '>'
+    else:
+      msg['From'] = self.mail
     if self.address_override:
       msg['To'] = self.address_override
     else:

--- a/libpius/mailer.py
+++ b/libpius/mailer.py
@@ -20,9 +20,10 @@ from libpius.util import clean_files, debug
 
 
 class PiusMailer(object):
-  def __init__(self, mail, host, port, user, tls, no_mime, override, msg_text,
-               tmp_dir):
+  def __init__(self, mail, display_name, host, port, user, tls, no_mime,
+               override, msg_text, tmp_dir):
     self.mail = mail
+    self.display_name = display_name
     self.host = host
     self.port = port
     self.user = user

--- a/libpius/util.py
+++ b/libpius/util.py
@@ -115,6 +115,14 @@ def check_email(_, opt, value):
                            ' formed email address' % (opt, value))
   return value
 
+def check_display_name(_, opt, value):
+  '''Ensure argument is a valid email display name.'''
+  match = re.search(r'[()<>[\]:;@\\,."]', value)
+  if match:
+    raise OptionValueError('Option %s: Value %s contains one or more illegal'
+                           ' characters' % (opt, value))
+  return value
+
 def check_keyid(_, opt, value):
   '''Ensure argument seems like a keyid.'''
   match = re.match(r'[0-9a-fA-Fx]', value)

--- a/libpius/util.py
+++ b/libpius/util.py
@@ -133,11 +133,12 @@ def check_keyid(_, opt, value):
 
 class MyOption(Option):
   '''Our own option class.'''
-  TYPES = Option.TYPES + ('not_another_opt', 'email', 'keyid')
+  TYPES = Option.TYPES + ('not_another_opt', 'email', 'display_name', 'keyid')
   TYPE_CHECKER = copy(Option.TYPE_CHECKER)
   TYPE_CHECKER.update({
       'not_another_opt': check_not_another_opt,
       'email': check_email,
+      'display_name': check_display_name,
       'keyid': check_keyid,
   })
 

--- a/pius
+++ b/pius
@@ -235,6 +235,7 @@ def main():
   if options.mail:
     mailer = pmailer.PiusMailer(
         options.mail,
+        options.display_name,
         options.mail_host,
         options.mail_port,
         options.mail_user,

--- a/pius
+++ b/pius
@@ -163,6 +163,9 @@ def main():
                     help='Email the encrypted, signed keys to the'
                          ' respective email addresses. EMAIL is the address'
                          ' to send from. See also -H and -P.')
+  parser.add_option('-D', '--display-name', dest='display_name', metavar="NAME",
+                    type='display_name',
+                    help='Email name to display, e.g., NAME <example@example.com>')
   parser.add_option('-N', '--no-sort-keyring', dest='sort_keyring',
                     action='store_false',
                     help='Do not sort the keyring by name.')


### PR DESCRIPTION
I added the option (`-D` or `--display-name`) to use an email display name (full name), e.g., `John Doe <john.doe@example.com>`