### PR TITLE
Constants for gpg path now being handled by util.gpg_path_test function

### DIFF
--- a/libpius/constants.py
+++ b/libpius/constants.py
@@ -1,11 +1,12 @@
 # vim:shiftwidth=2:tabstop=2:expandtab:textwidth=80:softtabstop=2:ai:
 
 import os
+import util
 
 VERSION = '2.2.6'
 HOME = os.environ.get('HOME')
 GNUPGHOME = os.environ.get('GNUPGHOME', os.path.join(HOME, '.gnupg'))
-DEFAULT_GPG_PATH = '/usr/bin/gpg2'
+DEFAULT_GPG_PATH = gpg_path_test()
 DEFAULT_KEYRING = os.path.join(GNUPGHOME, 'pubring.gpg')
 DEFAULT_TMP_DIR = '/tmp/pius_tmp'
 DEFAULT_OUT_DIR = '/tmp/pius_out'

--- a/libpius/util.py
+++ b/libpius/util.py
@@ -133,4 +133,19 @@ class MyOption(Option):
       'keyid': check_keyid,
   })
 
+  def which(pgm):
+    path=os.getenv('PATH')
+    for p in path.split(os.path.pathsep):
+      p=os.path.join(p,pgm)
+      if os.path.exists(p) and os.access(p,os.X_OK):
+          return p
+      else:
+          return ""
+
+  def gpg_path_test():
+      if(which("gpg2") != ""):
+          return which("gpg2")
+      else:
+          return "/usr/bin/gpg2"
+
 # END Stupid python optparse hack.

--- a/pius-keyring-mgr
+++ b/pius-keyring-mgr
@@ -34,7 +34,7 @@ DEFAULT_KEYSERVERS = [
 ]
 HOME = os.environ.get('HOME')
 GNUPGHOME = os.environ.get('GNUPGHOME', os.path.join(HOME, '.gnupg'))
-DEFAULT_GPG_PATH = '/usr/bin/gpg'
+DEFAULT_GPG_PATH = gpg_path_test()
 DEFAULT_CSV_DELIMITER = ','
 DEFAULT_CSV_NAME_FIELD = 2
 DEFAULT_CSV_EMAIL_FIELD = 3
@@ -453,7 +453,7 @@ Subject: %(party)sPGP Keysignign Party: Can't find your key!''' % interp
     util.logcmd(cmd)
     ret = subprocess.call(cmd, shell=False)
     sys.exit(ret)
-   
+
 # END class KeyringBuilder
 
 


### PR DESCRIPTION
This should fix the issue with cross platform users and is backwards compatible with older versions of python  < 2.7.x
Fixes #101 