### PR TITLE
Fixed pathing for OSes (GPG, TMP, Home, etc. for Windows/Linux/Unix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,27 +40,9 @@ And more! See the '-h' option for more.
 
 ## Security Implications
 
-The default mode for PIUS, starting in 2.2.0 is `agent` mode. If you
-are using gpg2 this is the only valid mode.
-
-If you aren't using gpg2, there are some other options. If you use
-`cache_passphrase` mode. This means that PIUS will ask you for your passphrase
-at startup, verify this passphrase is correct, and then feed it GnuPG everytime
-it needs it. The passphrase is stored in memory and only for the life of the
-execution of PIUS.  For most users this should be relatively safe. However, it
-is worth noting that if you are on a machine whose system administrators you
-don't trust, there is a small danger of them reading this memory while PIUS is
-running.
-
-Finally we have `interactive` mode which can be entered using -i. This will use
-pexpect to handle most of the signing interactions and then drop you into the
-'gpg --edit-key' shell whenever gpg needs a passphrase. Using this you can enter
-your passphrase directly into gpg. This mode has two main disadvantages. The
-first is that the pexpect code is quite fragile, and the second is that you'll
-have to type your passphrase for every key-UID combination.
-
-Both `interactive` and `cache_passphrase` mode will be removed in the next
-version when gpg1 support is dropped.
+As of 3.0, PIUS only works with gpg2 and later, and thus only works
+with a GPG Agent. Therefore, PIUS can never come into contact with your
+passphrase or your unencrypted private key.
 
 
 ## Sending Emails
@@ -150,9 +132,9 @@ not to be not that well documented and not work the way the documentation
 suggested.
 
 This method quickly showed itself to be very fragile. So, I managed to bend gpg
-to my will without using pexpect, and the only thing left that uses pexpect is
-the 'interactive' mode, which will probably one day go away if gpg-agent
-becomes reliable enough.
+to my will without using pexpect, and the only thing left that uses pexpect was
+the 'interactive' mode, which has been removed now that gpg-agent is both
+required in gpg 2.x and stable.
 
 
 ## License

--- a/doc/pius.1
+++ b/doc/pius.1
@@ -31,8 +31,6 @@ tool greatly reduces time and error when signing keys.
 show program's version number and exit
 .IP "\fB\-h\fP, \fB\-\-help\fP"
 show this help message and exit
-.IP "\fB\-a\fP, \fB\-\-use\-agent\fP"
-Use gpg-agent instead of letting gpg prompt the user or every UID. [default: true]
 .IP "\fB\-A\fP, \fB\-\-all\-keys\fP"
 Sign all keys on the keyring. Requires \fB\-r\fP.
 .IP "\fB\-d\fP, \fB\-\-debug\fP"
@@ -43,8 +41,6 @@ Path to gpg binary. [default: \fI/usr/bin/gpg2\fP]
 Encrypt output files with respective keys.
 .IP "\fB\-H\fP \fIHOSTNAME\fP, \fB\-\-mail\-host=\fP\fIHOSTNAME\fP"
 Hostname of SMTP server. [default: \fIlocalhost\fP]
-.IP "\fB\-i\fP, \fB\-\-interactive\fP"
-Use the pexpect module for signing and drop to the gpg shell for entering the passphrase. [default: false]
 .IP "\fB\-I\fP, \fB\-\-import\fP"
 Also import the unsigned keys from the keyring into the default keyring. Ignored if \fB\-r\fP is not specified, or if it's the same as the default keyring.
 .IP "\fB\-m\fP \fIFROM\-EMAIL\fP, \fB\-\-mail=\fP\fIFROM\-EMAIL\fP"
@@ -59,8 +55,6 @@ Rather than send to the user, send to this address. Mostly useful for debugging.
 Directory to put signed keys in. [default: \fI/tmp/pius_out\fP]
 .IP "\fB\-O\fP, \fB\-\-no\-pgp\-mime\fP"
 Do not use PGP/Mime when sending email.
-.IP "\fB\-p\fP, \fB\-\-cache\-passphrase\fP"
-Cache private key passphrase in memory and provide it to gpg instead of letting gpg prompt the user for every UID. [default: false]
 .IP "\fB\-P\fP \fIPORT\fP, \fB\-\-mail\-port=\fP\fIPORT\fP"
 \fIPort\fP of SMTP server. [default: 587]
 .IP "\fB\-r\fP \fIKEYRING\fP, \fB\-\-keyring=\fP\fIKEYRING\fP"

--- a/libpius/constants.py
+++ b/libpius/constants.py
@@ -3,9 +3,6 @@
 import os
 
 VERSION = '2.2.6'
-MODE_INTERACTIVE = 0
-MODE_CACHE_PASSPHRASE = 1
-MODE_AGENT = 2
 HOME = os.environ.get('HOME')
 GNUPGHOME = os.environ.get('GNUPGHOME', os.path.join(HOME, '.gnupg'))
 DEFAULT_GPG_PATH = '/usr/bin/gpg2'

--- a/libpius/constants.py
+++ b/libpius/constants.py
@@ -14,6 +14,7 @@ DEFAULT_MAIL_HOST = 'localhost'
 DEFAULT_MAIL_PORT = 587
 PIUS_HOME = path.get_piushome(HOME)
 PIUS_RC = os.path.join(PIUS_HOME, 'piusrc')
+LINUX_TEMP = '/tmp/'
 
 # Note the line with the email address on it below is intentionally
 # shorter than the rest to give it space to grow and still be < 80.

--- a/libpius/constants.py
+++ b/libpius/constants.py
@@ -1,17 +1,18 @@
 # vim:shiftwidth=2:tabstop=2:expandtab:textwidth=80:softtabstop=2:ai:
 
 import os
+from libpius import path
 
 VERSION = '2.2.6'
-HOME = os.environ.get('HOME')
-GNUPGHOME = os.environ.get('GNUPGHOME', os.path.join(HOME, '.gnupg'))
-DEFAULT_GPG_PATH = '/usr/bin/gpg2'
+HOME = path.get_home()
+GNUPGHOME = path.get_gpghome(HOME)
+DEFAULT_GPG_PATH = path.gpg_test()
 DEFAULT_KEYRING = os.path.join(GNUPGHOME, 'pubring.gpg')
-DEFAULT_TMP_DIR = '/tmp/pius_tmp'
-DEFAULT_OUT_DIR = '/tmp/pius_out'
+DEFAULT_TMP_DIR = path.set_tmpdir('pius_tmp')
+DEFAULT_OUT_DIR = path.set_tmpdir('pius_out')
 DEFAULT_MAIL_HOST = 'localhost'
 DEFAULT_MAIL_PORT = 587
-PIUS_HOME = os.path.join(HOME, '.pius')
+PIUS_HOME = path.get_piushome(HOME)
 PIUS_RC = os.path.join(PIUS_HOME, 'piusrc')
 
 # Note the line with the email address on it below is intentionally

--- a/libpius/constants.py
+++ b/libpius/constants.py
@@ -14,7 +14,6 @@ DEFAULT_MAIL_HOST = 'localhost'
 DEFAULT_MAIL_PORT = 587
 PIUS_HOME = path.get_piushome(HOME)
 PIUS_RC = os.path.join(PIUS_HOME, 'piusrc')
-LINUX_TEMP = '/tmp/'
 
 # Note the line with the email address on it below is intentionally
 # shorter than the rest to give it space to grow and still be < 80.

--- a/libpius/constants.py
+++ b/libpius/constants.py
@@ -13,7 +13,7 @@ DEFAULT_OUT_DIR = path.get_tmpdir('pius_out')
 DEFAULT_MAIL_HOST = 'localhost'
 DEFAULT_MAIL_PORT = 587
 PIUS_HOME = path.get_piushome(HOME)
-PIUS_RC = os.path.join(PIUS_HOME, 'piusrc')
+PIUS_RC = path.get_piusrc(HOME)
 
 # Note the line with the email address on it below is intentionally
 # shorter than the rest to give it space to grow and still be < 80.

--- a/libpius/constants.py
+++ b/libpius/constants.py
@@ -6,10 +6,10 @@ from libpius import path
 VERSION = '2.2.6'
 HOME = path.get_home()
 GNUPGHOME = path.get_gpghome(HOME)
-DEFAULT_GPG_PATH = path.gpg_test()
+DEFAULT_GPG_PATH = path.gpg_path()
 DEFAULT_KEYRING = os.path.join(GNUPGHOME, 'pubring.gpg')
-DEFAULT_TMP_DIR = path.set_tmpdir('pius_tmp')
-DEFAULT_OUT_DIR = path.set_tmpdir('pius_out')
+DEFAULT_TMP_DIR = path.get_tmpdir('pius_tmp')
+DEFAULT_OUT_DIR = path.get_tmpdir('pius_out')
 DEFAULT_MAIL_HOST = 'localhost'
 DEFAULT_MAIL_PORT = 587
 PIUS_HOME = path.get_piushome(HOME)

--- a/libpius/path.py
+++ b/libpius/path.py
@@ -4,11 +4,9 @@ from __future__ import print_function
 import os
 import sys
 import stat
+from libpius.constants import BIN_PATHs, LINUX_TEMPDIR
 from os.path import abspath
 import fnmatch
-
-
-LINUX_TEMP = '/tmp/'
 
 '''This is grabbed right from the python repo under lib/shutil.py'''
 
@@ -72,10 +70,13 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
                     return name
     return None
 
-def gpg_test():
-    gpg = which('gpg2')
+def gpg_path():
+    if sys.platform = "win32":
+        gpg = which('gpg2')
+    elif:
+        gpg = which('gpg2',path=BIN_PATHS)
     if gpg == "":
-        print("GPG2 could not be found! Is it accessable to $PATH?")
+        print("GPG2 could not be found! Do you have the correct permissions?")
         sys.exit(1)
     else:
         return gpg
@@ -98,7 +99,7 @@ def get_piushome(usrhome):
     else:
         return os.path.join(usrhome, '.pius')
 
-def set_tmpdir(dir):
+def get_tmpdir(dir):
     if sys.platform == "win32":
         tempdir = os.environ.get('TEMP')
         return os.path.join(tempdir, dir)

--- a/libpius/path.py
+++ b/libpius/path.py
@@ -83,37 +83,37 @@ def get_home():
     else:
         return os.environ.get('HOME')
 
-def get_gpghome(HOME):
+def get_gpghome(usrhome):
     if sys.platform == "win32":
-        return os.environ.get('GNUPGHOME', os.path.join(HOME, 'roaming\/gnupg'))
+        return os.environ.get('GNUPGHOME', os.path.join(usrhome, 'roaming\/gnupg'))
     else:
-        return os.environ.get('GNUPGHOME', os.path.join(HOME, '.gnupg'))
+        return os.environ.get('GNUPGHOME', os.path.join(usrhome, '.gnupg'))
 
-def get_piushome(HOME):
+def get_piushome(usrhome):
     if sys.platform == "win32":
-        return os.path.join(HOME, 'roaming\/pius')
+        return os.path.join(usrhome, 'roaming\/pius')
     else:
-        return os.path.join(HOME, '.pius')
+        return os.path.join(usrhome, '.pius')
 
 def set_tmpdir(dir):
     if sys.platform == "win32":
-        TMP = os.environ.get('TEMP')
-        return os.path.join(TMP, dir)
+        tempdir = os.environ.get('TEMP')
+        return os.path.join(tempdir, dir)
     elif sys.platform == "darwin":
         if os.environ.get('USER') == "root":
-            TMP = '/private/tmp/'
+            tempdir = '/private/tmp/'
         else:
-            TMP = os.environ.get('TMPDIR')
-        return os.path.join(TMP, dir)
+            tempdir = os.environ.get('TMPDIR')
+        return os.path.join(tempdir, dir)
     else:
         if os.environ.get('USER') == "root":
-            return os.path.join('/tmp/', dir)
+            tempdir = os.path.join('/tmp/', dir)
         elif os.environ.get('XDG_RUNTIME_DIR') != "":
-            return os.path.join(os.environ.get('XDG_RUNTIME_DIR'), dir)
+            tempdir = os.path.join(os.environ.get('XDG_RUNTIME_DIR'), dir)
         elif os.environ.get('TMPDIR') != "":
-            return os.path.join(os.environ.get('TMPDIR'), dir)
+            tempdir = os.path.join(os.environ.get('TMPDIR'), dir)
         else:
-            TMP = '/tmp/'
-        return os.path.join(TMP, dir)
+            tempdir = os.path.join(LINUX_TEMP, dir)
+        return tempdir 
 
 # END Stupid python optparse hack.

--- a/libpius/path.py
+++ b/libpius/path.py
@@ -7,6 +7,9 @@ import stat
 from os.path import abspath
 import fnmatch
 
+
+LINUX_TEMP = '/tmp/'
+
 '''This is grabbed right from the python repo under lib/shutil.py'''
 
 def which(cmd, mode=os.F_OK | os.X_OK, path=None):

--- a/libpius/path.py
+++ b/libpius/path.py
@@ -91,13 +91,13 @@ def get_home():
 
 def get_gpghome(usrhome):
     if sys.platform == "win32":
-        return os.environ.get('GNUPGHOME', os.path.join(usrhome, 'roaming\/gnupg'))
+        return os.environ.get('GNUPGHOME', os.path.join(usrhome, 'gnupg'))
     else:
         return os.environ.get('GNUPGHOME', os.path.join(usrhome, '.gnupg'))
 
 def get_piushome(usrhome):
     if sys.platform == "win32":
-        return os.path.join(usrhome, 'roaming\/pius')
+        return os.path.join(usrhome, 'pius')
     else:
         return os.path.join(usrhome, '.pius')
 

--- a/libpius/path.py
+++ b/libpius/path.py
@@ -8,7 +8,7 @@ from os.path import abspath
 import fnmatch
 
 LINUX_TEMPDIR = '/tmp/'
-LINUX_BIN_PATHS = '/usr/bin;/usr/sbin/;/bin;/sbin'
+LINUX_BIN_PATHS = '/usr/bin:/usr/sbin/:/bin:/sbin'
 #binaries is located right in the /usr/local/(program)/ folders
 MAC_BIN_PATHS = '/usr/local'
 
@@ -80,7 +80,7 @@ def gpg_path():
         gpg = which('gpg2')
     elif sys.platform == "darwin":
         #joining all possible paths for location of mac binaries
-        BIN_PATHS = MAC_BIN_PATHS+";"+LINUX_BIN_PATHS)
+        BIN_PATHS = MAC_BIN_PATHS+":"+LINUX_BIN_PATHS)
         gpg = which('gpg2', path=BIN_PATHS)
     elif sys.platform == "linux":
         gpg = which('gpg2', path=LINUX_BIN_PATHS)

--- a/libpius/path.py
+++ b/libpius/path.py
@@ -76,13 +76,13 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
 #end of "Which" function
 
 def gpg_path():
-    if sys.platform = "win32":
+    if sys.platform == "win32":
         gpg = which('gpg2')
-    elif sys.platform = "darwin":
+    elif sys.platform == "darwin":
         #joining all possible paths for location of mac binaries
-        BIN_PATHS = os.path.join(MAC_BIN_PATHS, LINUX_BIN_PATHS)
+        BIN_PATHS = MAC_BIN_PATHS+";"+LINUX_BIN_PATHS)
         gpg = which('gpg2', path=BIN_PATHS)
-    elif sys.platform = "linux":
+    elif sys.platform == "linux":
         gpg = which('gpg2', path=LINUX_BIN_PATHS)
     if gpg == "":
         print("GPG2 could not be found! Do you have the correct permissions?")
@@ -103,6 +103,7 @@ def get_gpghome(usrhome):
         return os.environ.get('GNUPGHOME', os.path.join(usrhome, '.gnupg'))
 
 def get_piushome(usrhome):
+    mode=os.F_OK | os.X_OK
     if sys.platform == "win32":
         return os.path.join(usrhome, 'pius')
     else:
@@ -112,7 +113,7 @@ def get_piushome(usrhome):
             piushome = os.path.join(os.environ.get('XDG_CONFIG_HOME'), '.pius')
         #long test to see if the path exists, is able to be accessed, and if it is a dir.
         #then join the usrhome path with ,config/.pius and return it to the program.
-        elif os.path.exists(os.path.join(usrhome, ',config')) and os.access(os.path.join(usrhome,'.config'), mode) and os.path.isdir(os.path.join(usrhome,'.config')):
+        elif os.path.exists(os.path.join(usrhome, '.config')) and os.access(os.path.join(usrhome,'.config'), mode) and os.path.isdir(os.path.join(usrhome,'.config')):
             piushome = os.path.join(usrhome,'.config/.pius')
         #fall back if above is not applicable
         elif:

--- a/libpius/path.py
+++ b/libpius/path.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 import os
 import sys
 import stat
-from libpius.constants import BIN_PATHs, LINUX_TEMPDIR
 from os.path import abspath
 import fnmatch
 

--- a/libpius/path.py
+++ b/libpius/path.py
@@ -8,6 +8,8 @@ from libpius.constants import BIN_PATHs, LINUX_TEMPDIR
 from os.path import abspath
 import fnmatch
 
+LINUX_TEMPDIR = '/tmp/'
+BIN_PATHS = '/usr/bin;/usr/sbin/;/bin;/sbin;/usr/local/bin;/usr/local/sbin'
 '''This is grabbed right from the python repo under lib/shutil.py'''
 
 def which(cmd, mode=os.F_OK | os.X_OK, path=None):

--- a/libpius/path.py
+++ b/libpius/path.py
@@ -8,7 +8,10 @@ from os.path import abspath
 import fnmatch
 
 LINUX_TEMPDIR = '/tmp/'
-BIN_PATHS = '/usr/bin;/usr/sbin/;/bin;/sbin;/usr/local/bin;/usr/local/sbin'
+LINUX_BIN_PATHS = '/usr/bin;/usr/sbin/;/bin;/sbin'
+#binaries is located right in the /usr/local/(program)/ folders
+MAC_BIN_PATHS = '/usr/local'
+
 '''This is grabbed right from the python repo under lib/shutil.py'''
 
 def which(cmd, mode=os.F_OK | os.X_OK, path=None):
@@ -75,8 +78,12 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
 def gpg_path():
     if sys.platform = "win32":
         gpg = which('gpg2')
-    elif:
-        gpg = which('gpg2',path=BIN_PATHS)
+    elif sys.platform = "darwin":
+        #joining all possible paths for location of mac binaries
+        BIN_PATHS = os.path.join(MAC_BIN_PATHS, LINUX_BIN_PATHS)
+        gpg = which('gpg2', path=BIN_PATHS)
+    elif sys.platform = "linux":
+        gpg = which('gpg2', path=LINUX_BIN_PATHS)
     if gpg == "":
         print("GPG2 could not be found! Do you have the correct permissions?")
         sys.exit(1)

--- a/libpius/path.py
+++ b/libpius/path.py
@@ -114,15 +114,27 @@ def get_piushome(usrhome):
         elif os.path.exists(os.path.join(usrhome, '.piusrc')) and os.access(os.path.join(usrhome,'.piusrc'), mode) and os.path.isdir(os.path.join(usrhome,'.piusrc')):
             piushome = os.path.join(usrhome,'.piusrc')
         elif os.environ.get('XDG_CONFIG_HOME') != "":
-            piushome = os.path.join(os.environ.get('XDG_CONFIG_HOME'), '.pius')
+            piushome = os.path.join(os.environ.get('XDG_CONFIG_HOME'), 'pius')
         #long test to see if the path exists, is able to be accessed, and if it is a dir.
         #then join the usrhome path with ,config/.pius and return it to the program.
         elif os.path.exists(os.path.join(usrhome, '.config')) and os.access(os.path.join(usrhome,'.config'), mode) and os.path.isdir(os.path.join(usrhome,'.config')):
-            piushome = os.path.join(usrhome,'.config/.pius')
+            piushome = os.path.join(usrhome,'.config/pius')
         #fall back if above is not applicable
-        elif:
+        else:
             piushome = os.path.join(usrhome, '.pius')
         return piushome
+    
+def get_piusrc(path):
+    if sys.platform == "win32":
+        if os.path.islink(path) and not os.path.isfile(path):
+            return os.path.join(path, 'piusrc')
+        elif os.path.isfile(path) and not os.path.islink(path):
+            return path
+    else:
+        if os.path.islink(path) and not os.path.isfile(path):
+            return os.path.join(path, 'piusrc')
+        elif os.path.isfile(path) and not os.path.islink(path):
+            return path
 
 def get_tmpdir(dir):
     if sys.platform == "win32":

--- a/libpius/path.py
+++ b/libpius/path.py
@@ -1,0 +1,109 @@
+'''A set of path functions and variables for the PIUS suite.'''
+from __future__ import print_function
+
+import os
+import sys
+import stat
+from os.path import abspath
+import fnmatch
+
+'''This is grabbed right from the python repo under lib/shutil.py'''
+
+def which(cmd, mode=os.F_OK | os.X_OK, path=None):
+    """Given a command, mode, and a PATH string, return the path which
+    conforms to the given mode on the PATH, or None if there is no such
+    file.
+    `mode` defaults to os.F_OK | os.X_OK. `path` defaults to the result
+    of os.environ.get("PATH"), or can be overridden with a custom search
+    path.
+    """
+    # Check that a given file can be accessed with the correct mode.
+    # Additionally check that `file` is not a directory, as on Windows
+    # directories pass the os.access check.
+    def _access_check(fn, mode):
+        return (os.path.exists(fn) and os.access(fn, mode)
+                and not os.path.isdir(fn))
+
+    # If we're given a path with a directory part, look it up directly rather
+    # than referring to PATH directories. This includes checking relative to the
+    # current directory, e.g. ./script
+    if os.path.dirname(cmd):
+        if _access_check(cmd, mode):
+            return cmd
+        return None
+
+    if path is None:
+        path = os.environ.get("PATH", os.defpath)
+    if not path:
+        return None
+    path = path.split(os.pathsep)
+
+    if sys.platform == "win32":
+        # The current directory takes precedence on Windows.
+        if not os.curdir in path:
+            path.insert(0, os.curdir)
+
+        # PATHEXT is necessary to check on Windows.
+        pathext = os.environ.get("PATHEXT", "").split(os.pathsep)
+        # See if the given file matches any of the expected path extensions.
+        # This will allow us to short circuit when given "python.exe".
+        # If it does match, only test that one, otherwise we have to try
+        # others.
+        if any(cmd.lower().endswith(ext.lower()) for ext in pathext):
+            files = [cmd]
+        else:
+            files = [cmd + ext for ext in pathext]
+    else:
+        # On other platforms you don't have things like PATHEXT to tell you
+        # what file suffixes are executable, so just pass on cmd as-is.
+        files = [cmd]
+
+    seen = set()
+    for dir in path:
+        normdir = os.path.normcase(dir)
+        if not normdir in seen:
+            seen.add(normdir)
+            for thefile in files:
+                name = os.path.join(dir, thefile)
+                if _access_check(name, mode):
+                    return name
+    return None
+
+def gpg_test():
+    gpg = which('gpg2')
+    if gpg == "":
+        print("GPG2 could not be found! Is it accessable to $PATH?")
+        sys.exit(1)
+    else:
+        return gpg
+
+def get_home():
+    if sys.platform == "win32":
+        return os.environ.get('APPDATA')
+    else:
+        return os.environ.get('HOME')
+
+def get_gpghome(HOME):
+    if sys.platform == "win32":
+        return os.environ.get('GNUPGHOME', os.path.join(HOME, 'roaming\/gnupg'))
+    else:
+        return os.environ.get('GNUPGHOME', os.path.join(HOME, '.gnupg'))
+
+def get_piushome(HOME):
+    if sys.platform == "win32":
+        return os.path.join(HOME, 'roaming\/pius')
+    else:
+        return os.path.join(HOME, '.pius')
+
+def set_tmpdir(dir):
+    if sys.platform == "win32":
+        TMP = os.environ.get('TEMP')
+        return os.path.join(TMP, dir)
+    elif sys.platfrom == "darwin":
+        TMP = '/private/tmp/'
+        return os.path.join(TMP, dir)
+    else:
+        TMP = '/tmp/'
+        return os.path.join(TMP, dir)
+
+# END Stupid python optparse hack.

--- a/libpius/path.py
+++ b/libpius/path.py
@@ -99,7 +99,18 @@ def get_piushome(usrhome):
     if sys.platform == "win32":
         return os.path.join(usrhome, 'pius')
     else:
-        return os.path.join(usrhome, '.pius')
+        #check to see if xdg home is a user env variable
+        #set it if it is to piushome
+        if os.environ.get('XDG_CONFIG_HOME') != "":
+            piushome = os.path.join(os.environ.get('XDG_CONFIG_HOME'), '.pius')
+        #long test to see if the path exists, is able to be accessed, and if it is a dir.
+        #then join the usrhome path with ,config/.pius and return it to the program.
+        elif os.path.exists(os.path.join(usrhome, ',config')) and os.access(os.path.join(usrhome,'.config'), mode) and os.path.isdir(os.path.join(usrhome,'.config')):
+            piushome = os.path.join(usrhome,'.config/.pius')
+        #fall back if above is not applicable
+        elif:
+            piushome = os.path.join(usrhome, '.pius')
+        return piushome
 
 def get_tmpdir(dir):
     if sys.platform == "win32":
@@ -117,8 +128,16 @@ def get_tmpdir(dir):
         #hard code the path for /tmp/
         if os.environ.get('USER') == "root":
             tempdir = os.path.join(LINUX_TEMPDIR, dir)
+        #See if XDG user temp dir exists in user variables
+        #and set it as the temp dir
+        elif os.environ.get('XDG_RUNTIME_DIR') != "":
+             tempdir = os.path.join(os.environ.get('XDG_RUNTIME_DIR'), dir)
+        #Check to see if tmpdir is a valid user env variable
+        #and set it as the tempdir if it is
         elif os.environ.get('TMPDIR') != "":
             tempdir = os.path.join(os.environ.get('TMPDIR'), dir)
+        #fall back to hard coded variable for temp dir if none
+        #of the above is found or applicable
         else:
             tempdir = os.path.join(LINUX_TEMPDIR, dir)
         return tempdir

--- a/libpius/path.py
+++ b/libpius/path.py
@@ -99,11 +99,21 @@ def set_tmpdir(dir):
     if sys.platform == "win32":
         TMP = os.environ.get('TEMP')
         return os.path.join(TMP, dir)
-    elif sys.platfrom == "darwin":
-        TMP = '/private/tmp/'
+    elif sys.platform == "darwin":
+        if os.environ.get('USER') == "root":
+            TMP = '/private/tmp/'
+        else:
+            TMP = os.environ.get('TMPDIR')
         return os.path.join(TMP, dir)
     else:
-        TMP = '/tmp/'
+        if os.environ.get('USER') == "root":
+            return os.path.join('/tmp/', dir)
+        elif os.environ.get('XDG_RUNTIME_DIR') != "":
+            return os.path.join(os.environ.get('XDG_RUNTIME_DIR'), dir)
+        elif os.environ.get('TMPDIR') != "":
+            return os.path.join(os.environ.get('TMPDIR'), dir)
+        else:
+            TMP = '/tmp/'
         return os.path.join(TMP, dir)
 
 # END Stupid python optparse hack.

--- a/libpius/path.py
+++ b/libpius/path.py
@@ -109,7 +109,11 @@ def get_piushome(usrhome):
     else:
         #check to see if xdg home is a user env variable
         #set it if it is to piushome
-        if os.environ.get('XDG_CONFIG_HOME') != "":
+        if os.path.exists(os.path.join(usrhome, '.pius')) and os.access(os.path.join(usrhome,'.pius'), mode) and os.path.isdir(os.path.join(usrhome,'.pius')):
+            piushome = os.path.join(usrhome,'.pius')
+        elif os.path.exists(os.path.join(usrhome, '.piusrc')) and os.access(os.path.join(usrhome,'.piusrc'), mode) and os.path.isdir(os.path.join(usrhome,'.piusrc')):
+            piushome = os.path.join(usrhome,'.piusrc')
+        elif os.environ.get('XDG_CONFIG_HOME') != "":
             piushome = os.path.join(os.environ.get('XDG_CONFIG_HOME'), '.pius')
         #long test to see if the path exists, is able to be accessed, and if it is a dir.
         #then join the usrhome path with ,config/.pius and return it to the program.

--- a/libpius/path.py
+++ b/libpius/path.py
@@ -70,6 +70,7 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
                 if _access_check(name, mode):
                     return name
     return None
+#end of "Which" function
 
 def gpg_path():
     if sys.platform = "win32":
@@ -111,14 +112,13 @@ def get_tmpdir(dir):
             tempdir = os.environ.get('TMPDIR')
         return os.path.join(tempdir, dir)
     else:
+        #When installing on a linux/unix system it needs root privilege
+        #root doesn't have a temp directory in its enviornment variables
+        #hard code the path for /tmp/
         if os.environ.get('USER') == "root":
             tempdir = os.path.join(LINUX_TEMPDIR, dir)
-        elif os.environ.get('XDG_RUNTIME_DIR') != "":
-            tempdir = os.path.join(os.environ.get('XDG_RUNTIME_DIR'), dir)
         elif os.environ.get('TMPDIR') != "":
             tempdir = os.path.join(os.environ.get('TMPDIR'), dir)
         else:
             tempdir = os.path.join(LINUX_TEMPDIR, dir)
-        return tempdir 
-
-# END Stupid python optparse hack.
+        return tempdir

--- a/libpius/path.py
+++ b/libpius/path.py
@@ -113,13 +113,13 @@ def get_tmpdir(dir):
         return os.path.join(tempdir, dir)
     else:
         if os.environ.get('USER') == "root":
-            tempdir = os.path.join('/tmp/', dir)
+            tempdir = os.path.join(LINUX_TEMPDIR, dir)
         elif os.environ.get('XDG_RUNTIME_DIR') != "":
             tempdir = os.path.join(os.environ.get('XDG_RUNTIME_DIR'), dir)
         elif os.environ.get('TMPDIR') != "":
             tempdir = os.path.join(os.environ.get('TMPDIR'), dir)
         else:
-            tempdir = os.path.join(LINUX_TEMP, dir)
+            tempdir = os.path.join(LINUX_TEMPDIR, dir)
         return tempdir 
 
 # END Stupid python optparse hack.

--- a/pius
+++ b/pius
@@ -32,7 +32,7 @@ from libpius import util
 from libpius.constants import (
     DEFAULT_GPG_PATH, DEFAULT_KEYRING, DEFAULT_MIME_EMAIL_TEXT,
     DEFAULT_NON_MIME_EMAIL_TEXT, DEFAULT_OUT_DIR, DEFAULT_TMP_DIR,
-    MODE_AGENT, MODE_CACHE_PASSPHRASE, MODE_INTERACTIVE, VERSION
+    VERSION
 )
 from libpius.exceptions import MailSendError
 from libpius.state import SignState
@@ -109,34 +109,17 @@ def warn_if_short_keyids(ids):
         print('ERROR: Danger not acknowledged, exiting.')
         sys.exit(1)
 
-def warn_for_gpg1():
-  print(
-    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-    "\n"
-    "!! WARNING: You are using GnuPG 1.x. Support for the 1.x series will be !!"
-    "\n"
-    "!!          dropped in the next release, please migrate to GnuPG 2.x.   !!"
-    "\n"
-    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-    "\n"
-  )
-
 def main():
   """Main."""
   usage = ('%prog [options] -s <signer_keyid> <keyid> [<keyid> ...]\n'
            '       %prog [options] -A -r <keyring_path> -s <signer_keyid>')
   parser = OptionParser(usage=usage, version='%%prog %s' % VERSION,
                         option_class=util.MyOption)
-  parser.set_defaults(mode=MODE_AGENT,
-                      gpg_path=DEFAULT_GPG_PATH,
+  parser.set_defaults(gpg_path=DEFAULT_GPG_PATH,
                       out_dir=DEFAULT_OUT_DIR,
                       tmp_dir=DEFAULT_TMP_DIR,
                       keyring=DEFAULT_KEYRING,
                       sort_keyring=True)
-  parser.add_option('-a', '--use-agent', action='store_const', const=MODE_AGENT,
-                    dest='mode',
-                    help='Use gpg-agent instead of letting gpg prompt the'
-                         ' user for every UID. [default: true]')
   parser.add_option('-A', '--all-keys', action='store_true', dest='all_keys',
                     help='Sign all keys on the keyring. Requires -r.')
   parser.add_option('-b', '--gpg-path', dest='gpg_path', metavar='PATH',
@@ -147,11 +130,6 @@ def main():
                     help='Encrypt output files with respective keys.')
   parser.add_option('-d', '--debug', action='store_true', dest='debug',
                     help='Enable debugging output.')
-  parser.add_option('-i', '--interactive', action='store_const',
-                    const=MODE_INTERACTIVE, dest='mode',
-                    help='Use the pexpect module for signing and drop to the'
-                         ' gpg shell for entering the passphrase. [default:'
-                         ' false]')
   parser.add_option('-I', '--import', action='store_true',
                     dest='import_keyring',
                     help='Also import the unsigned keys from the keyring'
@@ -169,11 +147,6 @@ def main():
   parser.add_option('-o', '--out-dir', dest='out_dir', metavar='OUTDIR',
                     nargs=1, type='not_another_opt',
                     help='Directory to put signed keys in. [default: %default]')
-  parser.add_option('-p', '--cache-passphrase', action='store_const',
-                    const=MODE_CACHE_PASSPHRASE, dest='mode',
-                    help='Cache private key passphrase in memory and provide'
-                         ' it to gpg instead of letting gpg prompt the user'
-                         ' for every UID. [default: false]')
   parser.add_option('-r', '--keyring', dest='keyring', metavar='KEYRING',
                     nargs=1, type='not_another_opt',
                     help='The keyring to use. Be sure to specify full or'
@@ -247,7 +220,6 @@ def main():
   signer = psigner.PiusSigner(
       options.signer,
       options.force_signer,
-      options.mode,
       options.keyring,
       options.gpg_path,
       options.tmp_dir,
@@ -261,12 +233,9 @@ def main():
       options.mail_host
   )
 
-  if signer.gpg2:
-    if options.mode != MODE_AGENT:
-      print("ERROR: gpg2 requires using an agent\n")
-      sys.exit(1)
-  else:
-    warn_for_gpg1()
+  if not signer.gpg2:
+    parser.error("ERROR: gpg2 or later is required!")
+    sys.exit(1)
 
   if options.all_keys:
     key_list = signer.get_all_keyids()
@@ -278,15 +247,6 @@ def main():
   else:
     warn_if_short_keyids(args)
     key_list = args
-
-  if options.mode == MODE_CACHE_PASSPHRASE:
-    print('NOTE: See the section on security implications in README.md.')
-    while True:
-      signer.get_passphrase()
-      if not signer.verify_passphrase():
-          print('Sorry, cannot unlock the key with that passphrase, try again.')
-      else:
-        break
 
   if options.mail_user:
     while True:

--- a/pius-keyring-mgr
+++ b/pius-keyring-mgr
@@ -35,12 +35,12 @@ DEFAULT_KEYSERVERS = [
 ]
 HOME = path.get_home()
 GNUPGHOME = path.get_gpghome(HOME)
-DEFAULT_GPG_PATH = path.gpg_test()
+DEFAULT_GPG_PATH = path.gpg_path()
 DEFAULT_CSV_DELIMITER = ','
 DEFAULT_CSV_NAME_FIELD = 2
 DEFAULT_CSV_EMAIL_FIELD = 3
 DEFAULT_CSV_FP_FIELD = 4
-DEFAULT_TMP_DIR = path.set_tmpdir('pius_keyring_mgr_tmp')
+DEFAULT_TMP_DIR = path.get_tmpdir('pius_keyring_mgr_tmp')
 
 DEFAULT_EMAIL_TEXT = '''Dear %(name)s,
 

--- a/pius-keyring-mgr
+++ b/pius-keyring-mgr
@@ -25,6 +25,7 @@ import sys
 from six.moves import input
 
 from libpius import util
+from libpius import path
 from libpius.constants import VERSION
 
 BADKEYS_RE = re.compile(r'00000000|12345678|no pgp key')
@@ -32,14 +33,14 @@ LIST_SEP_RE = re.compile(r'\s*,\s*')
 DEFAULT_KEYSERVERS = [
     'pool.sks-keyservers.net', 'pgp.mit.edu', 'keys.gnupg.net'
 ]
-HOME = os.environ.get('HOME')
-GNUPGHOME = os.environ.get('GNUPGHOME', os.path.join(HOME, '.gnupg'))
-DEFAULT_GPG_PATH = '/usr/bin/gpg'
+HOME = path.get_home()
+GNUPGHOME = path.get_gpghome(HOME)
+DEFAULT_GPG_PATH = path.gpg_test()
 DEFAULT_CSV_DELIMITER = ','
 DEFAULT_CSV_NAME_FIELD = 2
 DEFAULT_CSV_EMAIL_FIELD = 3
 DEFAULT_CSV_FP_FIELD = 4
-DEFAULT_TMP_DIR = '/tmp/pius_keyring_mgr_tmp'
+DEFAULT_TMP_DIR = path.set_tmpdir('pius_keyring_mgr_tmp')
 
 DEFAULT_EMAIL_TEXT = '''Dear %(name)s,
 
@@ -453,7 +454,7 @@ Subject: %(party)sPGP Keysignign Party: Can't find your key!''' % interp
     util.logcmd(cmd)
     ret = subprocess.call(cmd, shell=False)
     sys.exit(ret)
-   
+
 # END class KeyringBuilder
 
 


### PR DESCRIPTION
Updated single commit to better track/organize for pulling.

libpius/path.py handles pathing of the local machine and determines what to use or do based on the host OS.

set_tmpdir() is hard coded for Mac (Darwin) and linux as $TMPDIR doesn't respond correctly or is not an env variable in varying versions. 

(Note: MacOS uses mktemp which is not able to be accessed by anyone* except the user, some versions of linux use $TMP/$TEMP/$TMPDIR/$TEMPDIR or just doesn't exist at all)
*includes root