### PR TITLE
Use Python 2 on the shebang line

### DIFF
--- a/pius
+++ b/pius
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 """A utility to sign all UIDs on a list of PGP keys and PGP/Mime encrypt-email
 them to the respective emails."""
 

--- a/pius-keyring-mgr
+++ b/pius-keyring-mgr
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 '''A utility to create and manage party keyrings.'''
 
 # vim:tw=80:ai:tabstop=2:expandtab:shiftwidth=2

--- a/pius-report
+++ b/pius-report
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # vim:shiftwidth=2:tabstop=2:expandtab:textwidth=80:softtabstop=2:ai:
 #


### PR DESCRIPTION
Temporary fix for #124 while proper Python 3 support is not implemented.