### PR TITLE
Fix -e option

### DIFF
--- a/libpius/signer.py
+++ b/libpius/signer.py
@@ -399,6 +399,7 @@ class PiusSigner:
             stdout=subprocess.PIPE,
             stderr=self.null,
             close_fds=True,
+            text=True,
         )
 
         # Must send a blank line...


### PR DESCRIPTION
Ensure we are always dealing with strings and not bytes.

Fixes #138