### PR TITLE
Add support for SMTP SSL port (465)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ There are a variety of other options that you may want:
 * customize mail hostname and port (-H and -P respectively)
 * customize the email message (-M)
 * don't use PGP/Mime in the email (-O, implies -e)
-* specify a SMTPAUTH or STARTTLS for SMTP (-u and -S)
+* specify a SMTPAUTH/STARTTLS (-u and -S) or SSL (--ssl) for SMTP
 
 And more! See the '-h' option for more.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ There are a variety of other options that you may want:
 * customize mail hostname and port (-H and -P respectively)
 * customize the email message (-M)
 * don't use PGP/Mime in the email (-O, implies -e)
-* specify a SMTPAUTH/STARTTLS (-u and -S) or SSL (--ssl) for SMTP
+* specify SMTPAUTH (-u) and either STARTTLS (-S) or SSL (--ssl) for SMTP
 
 And more! See the '-h' option for more.
 

--- a/pius
+++ b/pius
@@ -300,6 +300,7 @@ def main():
             options.mail_port,
             options.mail_user,
             options.mail_tls,
+            options.mail_ssl,
             options.mail_no_pgp_mime,
             options.mail_override,
             options.mail_text,

--- a/pius
+++ b/pius
@@ -88,9 +88,12 @@ def check_options(parser, options, args):
         print("NOTE: -O and -m are present, turning on -e")
         options.encrypt_outfiles = True
 
-    if options.mail_user and not options.mail_tls:
-        print("NOTE: -u is present, turning off -S.")
+    if options.mail_user and not (options.mail_tls or options.mail_ssl):
+        print("NOTE: -u is present, enabling TLS by default.")
         options.mail_tls = True
+
+    if options.mail_tls and options.mail_ssl:
+        parser.error("ERROR: TLS and SSL cannot be used at the same time.")
 
     if options.mail_text and not options.mail:
         parser.error("ERROR: -M requires -m")

--- a/pius
+++ b/pius
@@ -89,7 +89,7 @@ def check_options(parser, options, args):
         options.encrypt_outfiles = True
 
     if options.mail_user and not (options.mail_tls or options.mail_ssl):
-        print("NOTE: -u is present, enabling TLS by default.")
+        print("NOTE: -u (SMTPAUTH) is present, enabling TLS. Either TLS or SSL is required with SMTPAUTH")
         options.mail_tls = True
 
     if options.mail_tls and options.mail_ssl:

--- a/pius-keyring-mgr
+++ b/pius-keyring-mgr
@@ -862,6 +862,7 @@ There are no options"""
                     options.mail_port,
                     options.mail_user,
                     options.mail_tls,
+                    options.mail_ssl,
                     options.mail_no_pgp_mime,
                     options.mail_override,
                     options.mail_text,

--- a/pius-report
+++ b/pius-report
@@ -550,6 +550,7 @@ def main():
             options.mail_port,
             options.mail_user,
             options.mail_tls,
+            options.mail_ssl,
             options.mail_no_pgp_mime,
             options.mail_override,
             options.mail_text,


### PR DESCRIPTION
Adds an option (--ssl) to use SSL instead of STARTTLS to gain support of mail servers supporting only this auth method.

According to [RFC8314](https://datatracker.ietf.org/doc/html/rfc8314) implicit SSL is recommended over STARTTLS for mail submission now.

Implements https://github.com/jaymzh/pius/issues/51