### PR TITLE
Use modern defaults for constants.

### DIFF
--- a/libpius/constants.py
+++ b/libpius/constants.py
@@ -7,8 +7,8 @@ VERSION = "3.0.0"
 
 HOME = os.environ.get("HOME")
 GNUPGHOME = os.environ.get("GNUPGHOME", os.path.join(HOME, ".gnupg"))
-DEFAULT_GPG_PATH = "/usr/bin/gpg2"
-DEFAULT_KEYRING = os.path.join(GNUPGHOME, "pubring.gpg")
+DEFAULT_GPG_PATH = "/usr/bin/gpg"
+DEFAULT_KEYRING = os.path.join(GNUPGHOME, "pubring.kbx")
 DEFAULT_TMP_DIR = "/tmp/pius_tmp"
 DEFAULT_OUT_DIR = "/tmp/pius_out"
 DEFAULT_MAIL_HOST = "localhost"


### PR DESCRIPTION
`/usr/bin/gpg2` has been "deprecated" in favor of `/usr/bin/gpg` since 2.1.23 (released in 2017-08-09).

Similarly, the default keyring has been `pubring.kbx` for a while now.