### PR TITLE
Sks servers are gone, gnupg.net too, updating to keys.openpgp.org

### DIFF
--- a/doc/pius-keyring-mgr.1
+++ b/doc/pius-keyring-mgr.1
@@ -54,7 +54,7 @@ The name of the party. Will be printed in the email sent out.
 Only useful with -m.
 .IP "\fB\-s\fP \fIKEY\-SERVER\fP, \fB\-\-keyservers=\fP\fIKEY\-SERVER\fP"
 Try this keyserver. Specify once for each server (-s foo -s bar).
-[default: pool.sks-keyservers.net, pgp.mit.edu, keys.gnupg.net]
+[default: pgp.mit.edu, keys.openpgp.org]
 .IP "\fB\-t\fP \fITEMP\-DIR\fP, \fB\-\-tmp\-dir=\fP\fITEMP\-DIR\fP"
 Directory to put temporary stuff in. [default: \fI/tmp/pius_keyring_mgr_tmp\fP]
 .IP "\fB\-T\fP, \fB\-\-print\-default\-email\fP"

--- a/libpius/constants.py
+++ b/libpius/constants.py
@@ -74,7 +74,7 @@ Something like this should work:
 
 Then, don't forget to send it to a keyserver:
 
-   gpg --keyserver pool.sks-keyservers.net --send-key %(keyid)s
+   gpg --keyserver keys.openpgp.org --send-key %(keyid)s
 
 If you have any questions, let me know.
 
@@ -99,7 +99,7 @@ Something like this should work:
 
 Then, don't forget to send it to a keyserver:
 
-   gpg --keyserver pool.sks-keyservers.net --send-key %(keyid)s
+   gpg --keyserver keys.openpgp.org --send-key %(keyid)s
 
 If you have any questions, let me know.
 

--- a/pius-keyring-mgr
+++ b/pius-keyring-mgr
@@ -36,9 +36,8 @@ from libpius.constants import (
 BADKEYS_RE = re.compile(r"00000000|12345678|no pgp key")
 LIST_SEP_RE = re.compile(r"\s*,\s*")
 DEFAULT_KEYSERVERS = [
-    "pool.sks-keyservers.net",
     "pgp.mit.edu",
-    "keys.gnupg.net",
+    "keys.openpgp.org",
 ]
 DEFAULT_GPG_PATH = "/usr/bin/gpg"
 DEFAULT_CSV_DELIMITER = ","


### PR DESCRIPTION
Cleanup and remove the sks pool as they are offline. I've kept MIT as it's still responding. gnupg.net didn't respond either, so updated all to keys.openpgpg.org