### PR TITLE
Handle raw emails as UID value in keys

### DIFF
--- a/libpius/util.py
+++ b/libpius/util.py
@@ -27,7 +27,8 @@ class PiusUtil:
             print("DEBUG:", line)
 
     def logcmd(cmd):
-        PiusUtil.debug("Running: %s" % " ".join(cmd))
+        outcmd = " ".join(cmd) if type(cmd) == list else cmd
+        PiusUtil.debug("Running: %s" % outcmd)
 
     def clean_files(flist):
         """Delete a list of files."""


### PR DESCRIPTION
UIDs usually follow the form of `Name <user@domain.tld>`, but they can
be just raw emails (`user@domain.tld`), so support that.

Fixes #111

Signed-off-by: Phil Dibowitz <phil@ipom.com>
